### PR TITLE
Project: Build with clang

### DIFF
--- a/QSD8250Pkg/Application/HtcLeoMenuApp/menu.c
+++ b/QSD8250Pkg/Application/HtcLeoMenuApp/menu.c
@@ -11,13 +11,13 @@ void
 FillMenu()
 {
   UINTN Index = 0;
-  MenuOptions[Index++] = (MenuEntry){Index, L"Boot default", TRUE, &BootDefault};
-  MenuOptions[Index++] = (MenuEntry){Index, L"Play Tetris", TRUE, &StartTetris};
-  MenuOptions[Index++] = (MenuEntry){Index, L"EFI Shell", TRUE, &StartShell},
-  MenuOptions[Index++] = (MenuEntry){Index, L"Dump DMESG to sdcard", TRUE, &DumpDmesg},
-  MenuOptions[Index++] = (MenuEntry){Index, L"Dump Memory to sdcard", TRUE, &DumpMemory2Sdcard},
-  MenuOptions[Index++] = (MenuEntry){Index, L"Reboot Menu", TRUE, &RebootMenu};
-  MenuOptions[Index++] = (MenuEntry){Index, L"Exit", TRUE, &ExitMenu};
+  MenuOptions[Index++] = (MenuEntry){L"Boot default", TRUE, &BootDefault};
+  MenuOptions[Index++] = (MenuEntry){L"Play Tetris", TRUE, &StartTetris};
+  MenuOptions[Index++] = (MenuEntry){L"EFI Shell", TRUE, &StartShell},
+  MenuOptions[Index++] = (MenuEntry){L"Dump DMESG to sdcard", TRUE, &DumpDmesg},
+  MenuOptions[Index++] = (MenuEntry){L"Dump Memory to sdcard", TRUE, &DumpMemory2Sdcard},
+  MenuOptions[Index++] = (MenuEntry){L"Reboot Menu", TRUE, &RebootMenu};
+  MenuOptions[Index++] = (MenuEntry){L"Exit", TRUE, &ExitMenu};
 }
 
 void PrepareConsole(
@@ -96,7 +96,7 @@ void DrawMenu()
       gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_BLACK));
     }
 
-    Print(L"%d. %s ", MenuOptions[i].Index, MenuOptions[i].Name);
+    Print(L"%d. %s ", i+1, MenuOptions[i].Name);
   }
 }
 
@@ -213,12 +213,12 @@ void RebootMenu(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
   
   Status = SystemTable->ConOut->ClearScreen(SystemTable->ConOut);
   ASSERT_EFI_ERROR(Status);
-  MenuOptions[Index++] = (MenuEntry){Index, L"Reboot to CLK", TRUE, &NullFunction};
-  MenuOptions[Index++] = (MenuEntry){Index, L"Reboot", TRUE, &ResetCold};
-  MenuOptions[Index++] = (MenuEntry){Index, L"Shutdown", TRUE, &ResetShutdown};
+  MenuOptions[Index++] = (MenuEntry){L"Reboot to CLK", TRUE, &NullFunction};
+  MenuOptions[Index++] = (MenuEntry){L"Reboot", TRUE, &ResetCold};
+  MenuOptions[Index++] = (MenuEntry){L"Shutdown", TRUE, &ResetShutdown};
   // Fill disabled options
   do {
-    MenuOptions[Index++] = (MenuEntry){Index, L"", FALSE, &NullFunction};
+    MenuOptions[Index++] = (MenuEntry){L"", FALSE, &NullFunction};
   }while(Index < MAX_OPTIONS_COUNT);
 }
 

--- a/QSD8250Pkg/Application/HtcLeoMenuApp/menu.c
+++ b/QSD8250Pkg/Application/HtcLeoMenuApp/menu.c
@@ -10,20 +10,14 @@ EFI_SIMPLE_TEXT_OUTPUT_MODE InitialMode;
 void
 FillMenu()
 {
-  UINTN Index = 1;
-  MenuOptions[Index] = (MenuEntry){Index, L"Boot default", TRUE, &BootDefault};
-  Index++;
-  MenuOptions[Index] = (MenuEntry){Index, L"Play Tetris", TRUE, &StartTetris};
-  Index++;
-  MenuOptions[Index] = (MenuEntry){Index, L"EFI Shell", TRUE, &StartShell};
-  Index++;
-  MenuOptions[Index] = (MenuEntry){Index, L"Dump DMESG to sdcard", TRUE, &DumpDmesg};
-  Index++;
-  MenuOptions[Index] = (MenuEntry){Index, L"Dump Memory to sdcard", TRUE, &DumpMemory2Sdcard};
-  Index++;
-  MenuOptions[Index] = (MenuEntry){Index, L"Reboot Menu", TRUE, &RebootMenu};
-  Index++;
-  MenuOptions[Index] = (MenuEntry){Index, L"Exit", TRUE, &ExitMenu};
+  UINTN Index = 0;
+  MenuOptions[Index++] = (MenuEntry){Index, L"Boot default", TRUE, &BootDefault};
+  MenuOptions[Index++] = (MenuEntry){Index, L"Play Tetris", TRUE, &StartTetris};
+  MenuOptions[Index++] = (MenuEntry){Index, L"EFI Shell", TRUE, &StartShell},
+  MenuOptions[Index++] = (MenuEntry){Index, L"Dump DMESG to sdcard", TRUE, &DumpDmesg},
+  MenuOptions[Index++] = (MenuEntry){Index, L"Dump Memory to sdcard", TRUE, &DumpMemory2Sdcard},
+  MenuOptions[Index++] = (MenuEntry){Index, L"Reboot Menu", TRUE, &RebootMenu};
+  MenuOptions[Index++] = (MenuEntry){Index, L"Exit", TRUE, &ExitMenu};
 }
 
 void PrepareConsole(
@@ -214,20 +208,17 @@ void StartTetris(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
 void RebootMenu(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
 {
   SelectedIndex     = 0;
-  UINT8 Index = 1;
+  UINT8 Index = 0;
   EFI_STATUS Status = EFI_SUCCESS;
   
   Status = SystemTable->ConOut->ClearScreen(SystemTable->ConOut);
   ASSERT_EFI_ERROR(Status);
-  MenuOptions[Index] = (MenuEntry){Index, L"Reboot to CLK", TRUE, &NullFunction};
-  Index++;
-  MenuOptions[Index] = (MenuEntry){Index, L"Reboot", TRUE, &ResetCold};
-  Index++;
-  MenuOptions[Index] = (MenuEntry){Index, L"Shutdown", TRUE, &ResetShutdown};
+  MenuOptions[Index++] = (MenuEntry){Index, L"Reboot to CLK", TRUE, &NullFunction};
+  MenuOptions[Index++] = (MenuEntry){Index, L"Reboot", TRUE, &ResetCold};
+  MenuOptions[Index++] = (MenuEntry){Index, L"Shutdown", TRUE, &ResetShutdown};
   // Fill disabled options
   do {
-    Index++;
-    MenuOptions[Index] = (MenuEntry){Index, L"", FALSE, &NullFunction};
+    MenuOptions[Index++] = (MenuEntry){Index, L"", FALSE, &NullFunction};
   }while(Index < MAX_OPTIONS_COUNT);
 }
 

--- a/QSD8250Pkg/Application/HtcLeoMenuApp/menu.c
+++ b/QSD8250Pkg/Application/HtcLeoMenuApp/menu.c
@@ -10,14 +10,20 @@ EFI_SIMPLE_TEXT_OUTPUT_MODE InitialMode;
 void
 FillMenu()
 {
-  UINTN Index = 0;
-  MenuOptions[Index++] = (MenuEntry){Index, L"Boot default", TRUE, &BootDefault};
-  MenuOptions[Index++] = (MenuEntry){Index, L"Play Tetris", TRUE, &StartTetris};
-  MenuOptions[Index++] = (MenuEntry){Index, L"EFI Shell", TRUE, &StartShell},
-  MenuOptions[Index++] = (MenuEntry){Index, L"Dump DMESG to sdcard", TRUE, &DumpDmesg},
-  MenuOptions[Index++] = (MenuEntry){Index, L"Dump Memory to sdcard", TRUE, &DumpMemory2Sdcard},
-  MenuOptions[Index++] = (MenuEntry){Index, L"Reboot Menu", TRUE, &RebootMenu};
-  MenuOptions[Index++] = (MenuEntry){Index, L"Exit", TRUE, &ExitMenu};
+  UINTN Index = 1;
+  MenuOptions[Index] = (MenuEntry){Index, L"Boot default", TRUE, &BootDefault};
+  Index++;
+  MenuOptions[Index] = (MenuEntry){Index, L"Play Tetris", TRUE, &StartTetris};
+  Index++;
+  MenuOptions[Index] = (MenuEntry){Index, L"EFI Shell", TRUE, &StartShell};
+  Index++;
+  MenuOptions[Index] = (MenuEntry){Index, L"Dump DMESG to sdcard", TRUE, &DumpDmesg};
+  Index++;
+  MenuOptions[Index] = (MenuEntry){Index, L"Dump Memory to sdcard", TRUE, &DumpMemory2Sdcard};
+  Index++;
+  MenuOptions[Index] = (MenuEntry){Index, L"Reboot Menu", TRUE, &RebootMenu};
+  Index++;
+  MenuOptions[Index] = (MenuEntry){Index, L"Exit", TRUE, &ExitMenu};
 }
 
 void PrepareConsole(
@@ -208,17 +214,20 @@ void StartTetris(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
 void RebootMenu(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
 {
   SelectedIndex     = 0;
-  UINT8 Index = 0;
+  UINT8 Index = 1;
   EFI_STATUS Status = EFI_SUCCESS;
   
   Status = SystemTable->ConOut->ClearScreen(SystemTable->ConOut);
   ASSERT_EFI_ERROR(Status);
-  MenuOptions[Index++] = (MenuEntry){Index, L"Reboot to CLK", TRUE, &NullFunction};
-  MenuOptions[Index++] = (MenuEntry){Index, L"Reboot", TRUE, &ResetCold};
-  MenuOptions[Index++] = (MenuEntry){Index, L"Shutdown", TRUE, &ResetShutdown};
+  MenuOptions[Index] = (MenuEntry){Index, L"Reboot to CLK", TRUE, &NullFunction};
+  Index++;
+  MenuOptions[Index] = (MenuEntry){Index, L"Reboot", TRUE, &ResetCold};
+  Index++;
+  MenuOptions[Index] = (MenuEntry){Index, L"Shutdown", TRUE, &ResetShutdown};
   // Fill disabled options
   do {
-    MenuOptions[Index++] = (MenuEntry){Index, L"", FALSE, &NullFunction};
+    Index++;
+    MenuOptions[Index] = (MenuEntry){Index, L"", FALSE, &NullFunction};
   }while(Index < MAX_OPTIONS_COUNT);
 }
 

--- a/QSD8250Pkg/Application/HtcLeoMenuApp/menu.h
+++ b/QSD8250Pkg/Application/HtcLeoMenuApp/menu.h
@@ -26,7 +26,6 @@
 #define _MAIN_MENU_H_
 
 typedef struct {
-  UINT8   Index;
   CHAR16 *Name;
   BOOLEAN IsActive;
   void (*Function)();

--- a/QSD8250Pkg/CommonDsc.dsc.inc
+++ b/QSD8250Pkg/CommonDsc.dsc.inc
@@ -13,6 +13,8 @@
 #
 #
 
+!include MdePkg/MdeLibs.dsc.inc
+
 [LibraryClasses.common]
 !if $(TARGET) == RELEASE
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf

--- a/QSD8250Pkg/CommonDsc.dsc.inc
+++ b/QSD8250Pkg/CommonDsc.dsc.inc
@@ -67,7 +67,6 @@
   DefaultExceptionHandlerLib|QSD8250Pkg/Library/DefaultExceptionHandlerLib/DefaultExceptionHandlerLib.inf
   CpuExceptionHandlerLib|ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.inf
   ArmDisassemblerLib|ArmPkg/Library/ArmDisassemblerLib/ArmDisassemblerLib.inf
-  ArmPlatformStackLib|ArmPlatformPkg/Library/ArmPlatformStackLib/ArmPlatformStackLib.inf
   ArmSmcLib|ArmPkg/Library/ArmSmcLib/ArmSmcLib.inf
   ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
 
@@ -123,21 +122,10 @@
   EdkiiSystemCapsuleLib|SignedCapsulePkg/Library/EdkiiSystemCapsuleLib/EdkiiSystemCapsuleLib.inf
   IniParsingLib|SignedCapsulePkg/Library/IniParsingLib/IniParsingLib.inf
 
-  #
-  # It is not possible to prevent the ARM compiler for generic intrinsic functions.
-  # This library provides the instrinsic functions generate by a given compiler.
-  # And NULL mean link this library into all ARM images.
-  #
-  NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
-
-  # Add support for GCC stack protector
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
-
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
   ArmPlatformLib|QSD8250Pkg/Library/QSD8250PkgLib/QSD8250PkgLib.inf
   TimerLib|QSD8250Pkg/Library/GPTTimerLib/GPTTimerLib.inf
-  CompilerIntrinsicsLib|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
   PlatformBootManagerLib|QSD8250Pkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
   UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -171,7 +159,6 @@
   # Framebuffer
   FrameBufferBltLib|MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.inf
   MemoryInitPeiLib|ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
-  CompilerIntrinsicsLib|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
   # Little kernel libraries
   MsmPcomLib|QSD8250Pkg/Library/MsmPcomLib/MsmPcomLib.inf

--- a/QSD8250Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
+++ b/QSD8250Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
@@ -35,7 +35,6 @@
   UefiDriverEntryPoint
   BaseMemoryLib
   DebugLib
-  CompilerIntrinsicsLib
 
 [Guids.common]
   gQcomTokenSpaceGuid

--- a/QSD8250Pkg/Drivers/SmemDxe/SmemDxe.inf
+++ b/QSD8250Pkg/Drivers/SmemDxe/SmemDxe.inf
@@ -24,7 +24,6 @@
   MemoryAllocationLib
   UefiDriverEntryPoint
   UefiBootServicesTableLib
-  CompilerIntrinsicsLib
   CacheMaintenanceLib
   DxeServicesTableLib
   IoLib

--- a/QSD8250Pkg/Drivers/SmemDxe/SmemLib.inf
+++ b/QSD8250Pkg/Drivers/SmemDxe/SmemLib.inf
@@ -20,7 +20,6 @@
   BaseLib
   UefiBootServicesTableLib
   IoLib
-  CompilerIntrinsicsLib
   CacheMaintenanceLib
 
 [Protocols]

--- a/QSD8250Pkg/Drivers/SmemPtableDxe/SmemPtableDxe.inf
+++ b/QSD8250Pkg/Drivers/SmemPtableDxe/SmemPtableDxe.inf
@@ -29,7 +29,6 @@
   DebugLib
   IoLib
   MemoryAllocationLib
-  CompilerIntrinsicsLib
   CacheMaintenanceLib
   DxeServicesTableLib
 

--- a/QSD8250Pkg/Library/FrameBufferSerialPortLib/FrameBufferSerialPortLib.inf
+++ b/QSD8250Pkg/Library/FrameBufferSerialPortLib/FrameBufferSerialPortLib.inf
@@ -18,7 +18,6 @@
   PcdLib
   IoLib
   HobLib
-  CompilerIntrinsicsLib
   CacheMaintenanceLib
 
 [Pcd]

--- a/QSD8250Pkg/Library/QSD8250PkgLib/QSD8250PkgHelper.S
+++ b/QSD8250Pkg/Library/QSD8250PkgLib/QSD8250PkgHelper.S
@@ -11,7 +11,7 @@
 #
 #
 
-#include <AsmMacroIoLib.h>
+#include <AsmMacroLib.h>
 #include <Library/ArmLib.h>
 
 ASM_FUNC(ArmPlatformPeiBootAction)

--- a/QSD8250Pkg/PrePi/Arm/ModuleEntryPoint.S
+++ b/QSD8250Pkg/PrePi/Arm/ModuleEntryPoint.S
@@ -5,7 +5,7 @@
 //
 //
 
-#include <AsmMacroIoLib.h>
+#include <AsmMacroLib.h>
 
 #include <Arm/AArch32.h>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ steps:
     architecture: 'x64'
   displayName: Install correct Python
 
-- script:  sudo apt -y install build-essential uuid-dev iasl git nasm python3-distutils crossbuild-essential-armel skales gcc-arm-none-eabi mkbootimg
+- script:  sudo apt -y install build-essential uuid-dev iasl git nasm python3-distutils crossbuild-essential-armel skales gcc-arm-none-eabi mkbootimg clang llvm lld
   displayName: 'Install VSTS dependencies'
 
 - script: sudo ln -sfn $(pwd) ../HtcLeoPkg

--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,8 @@ function _build(){
 	shift
 	source "../edk2/edksetup.sh"
 
+	NUM_CPUS=$((`getconf _NPROCESSORS_ONLN` + 2))
+
 	# Clean artifacts if needed
 	_clean
 	echo "Artifacts removed"
@@ -63,14 +65,14 @@ if [ $DEVICE == 'All' ]; then
 	do
 		if [ $PlatformName != 'All' ]; then
 			# Build
-			GCC_ARM_PREFIX=arm-none-eabi- build -s -n 0 -a ARM -t GCC -p Platforms/Htc${PlatformName}/Htc${PlatformName}Pkg.dsc
+			build -n $NUM_CPUS -a ARM -t CLANGDWARF -p Platforms/Htc${PlatformName}/Htc${PlatformName}Pkg.dsc -b DEBUG
 			./build_boot_shim.sh
 			./build_boot_images.sh $PlatformName
 		fi
 	done
 else
     echo "Building uefi for $DEVICE"
-	GCC_ARM_PREFIX=arm-none-eabi- build -s -n 0 -a ARM -t GCC -p Platforms/Htc${DEVICE}/Htc${DEVICE}Pkg.dsc
+	build -n $NUM_CPUS -a ARM -t CLANGDWARF -p Platforms/Htc${DEVICE}/Htc${DEVICE}Pkg.dsc -b DEBUG
 
 	./build_boot_shim.sh
 	./build_boot_images.sh $DEVICE

--- a/build_boot_images.sh
+++ b/build_boot_images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ $1 == 'Leo' ]; then
-    cat BootShim/BootShim.bin workspace/Build/HtcLeo/DEBUG_GCC/FV/QSD8250_UEFI.fd >>ImageResources/Leo/bootpayload.bin
+    cat BootShim/BootShim.bin workspace/Build/HtcLeo/DEBUG_CLANGDWARF/FV/QSD8250_UEFI.fd >>ImageResources/Leo/bootpayload.bin
 
     mkbootimg --kernel ImageResources/Leo/bootpayload.bin --base 0x11800000 --kernel_offset 0x00008000 -o ImageResources/Leo/uefi.img
 
@@ -18,7 +18,7 @@ if [ $1 == 'Leo' ]; then
     ./yang -F LEOIMG.nbh -f logo.nb,os.nb -t 0x600,0x400 -s 64 -d PB8110000 -c 11111111 -v EDK2 -l WWE
     cd ../../
 elif [ $1 == 'Schubert' ]; then
-    cat BootShim/BootShim.bin workspace/Build/HtcSchubert/DEBUG_GCC/FV/QSD8250_UEFI.fd >>ImageResources/$1/bootpayload.bin
+    cat BootShim/BootShim.bin workspace/Build/HtcSchubert/DEBUG_CLANGDWARF/FV/QSD8250_UEFI.fd >>ImageResources/$1/bootpayload.bin
 
     mkbootimg --kernel ImageResources/$1/bootpayload.bin --base 0x20000000 --kernel_offset 0x00008000 -o ImageResources/$1/uefi.img
 else


### PR DESCRIPTION
As found by Aljoshua it seems that the tools config has -mstack-protector-guard=global set for ARM ([see here](https://github.com/tianocore/edk2/blob/bbcdc0b7d9822c1014d563aaf12d8f43aea1a2e1/BaseTools/Conf/tools_def.template#L898)), but it is [not supported](https://gcc.gnu.org/onlinedocs/gcc-10.1.0/gcc/ARM-Options.html#ARM-Options), producing an error. Hence me trying to switch to clang for now.